### PR TITLE
Remove redeclarations

### DIFF
--- a/gnomeGlobalAppMenu@lestcape/configurableMenus.js
+++ b/gnomeGlobalAppMenu@lestcape/configurableMenus.js
@@ -731,7 +731,7 @@ BoxPointer.prototype = {
         let margin = (4 * borderRadius + borderWidth + arrowBase);
         let halfMargin = margin / 2;
 
-        let themeNode = this.actor.get_theme_node();
+        themeNode = this.actor.get_theme_node();
         let gap = themeNode.get_length('-boxpointer-gap');
 
         let resX, resY;
@@ -6841,7 +6841,7 @@ ConfigurableGridSection.prototype = {
       //return portSize;
       let spaceBox = new Clutter.ActorBox();
       x = box.x1 + leftEmptySpace;
-      let spaceBox = this._calculateSpaceBox(this._spaceActor, x, y, box);
+      spaceBox = this._calculateSpaceBox(this._spaceActor, x, y, box);
       this._spaceActor.allocate(spaceBox, flags);
       this.box.set_skip_paint(this._spaceActor, false);
       //Main.notify("" + spaceBox.y2 + "-" + spaceBox.y1 + "-" + spaceBox.x2 + "-" + spaceBox.x1);
@@ -8185,7 +8185,7 @@ MenuFactory.prototype = {
               PopupMenu using a non instance of the class PopupMenuAbstractFactory");
       }
       // The shell menu
-      let shellItem = this._createShellItem(factoryMenu, launcher, orientation, menuManager);
+      shellItem = this._createShellItem(factoryMenu, launcher, orientation, menuManager);
       this._attachToMenu(shellItem, factoryMenu);
       this._menuManager.push(menuManager);
       return shellItem;
@@ -8356,7 +8356,7 @@ MenuFactory.prototype = {
       let factoryItemParent = factoryItem.getParent();
       let parentMenu = null;
       if(factoryItemParent) {
-         let shellItemParent = factoryItemParent.getShellItem();
+         shellItemParent = factoryItemParent.getShellItem();
          if(shellItemParent instanceof ConfigurablePopupMenuSection)
             parentMenu = shellItemParent;
          else


### PR DESCRIPTION
Extension won't load on GNOME 2.24 on Ubuntu 17.04 because of redeclaration of variables.
 
Here's a sample output from `journalctl /usr/bin/gnome-shell`:
```
JS ERROR: Exception in callback for signal: extension-found: TypeError: redeclaration of let themeNode
@/home/shemgp/.local/share/gnome-shell/extensions/gnomeGlobalAppMenu@lestcape/extensionManager.js:30:7
@/home/shemgp/.local/share/gnome-shell/extensions/gnomeGlobalAppMenu@lestcape/extension.js:8:7
initExtension@resource:///org/gnome/shell/ui/extensionSystem.js:221:5
loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:168:18
_loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:304:9
_emit@resource:///org/gnome/gjs/modules/signals.js:126:27
ExtensionFinder<._loadExtension@resource:///org/gnome/shell/misc/extensionUtils.js:184:9
wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
bind/<@resource:///org/gnome/gjs/modules/lang.js:95:16
collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:1
ExtensionFinder<.scanExtensions@resource:///org/gnome/shell/misc/extensionUtils.js:189:9
wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
_loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:306:5
enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:314:9
_sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:345:9
init@resource:///org/gnome/shell/ui/extensionSystem.js:353:5
_initializeUI@resource:///org/gnome/shell/ui/main.js:219:5
start@resource:///org/gnome/shell/ui/main.js:127:5
@<main>:1:31
```

With this PR it will load but I can't still see the global menu.