### PR TITLE
fix xwininfo -children -id 0xNaN cause crosshairs mouse cursor issue

### DIFF
--- a/gnomeGlobalAppMenu@lestcape/indicatorAppMenuWatcher.js
+++ b/gnomeGlobalAppMenu@lestcape/indicatorAppMenuWatcher.js
@@ -784,7 +784,7 @@ IndicatorAppMenuWatcher.prototype = {
 
       // Use xwininfo, take first child.
       let act = wind.get_compositor_private();
-      if(act) {
+      if(act && act['x-window']) {
          id = GLib.spawn_command_line_sync('xwininfo -children -id 0x%x'.format(act['x-window']));
          if(id[0]) {
             let str = id[1].toString();


### PR DESCRIPTION
Tested on Ubuntu Gnome 16.04, this should fixed the issue like below:
[Many windows demand additional click for the placement](https://github.com/wilfm/GnomeExtensionMaximusTwo/issues/50)