### PR TITLE
Use _leftBox as an anchor instead of activities which may not be there

### DIFF
--- a/gnomeGlobalAppMenu@lestcape/extension.js
+++ b/gnomeGlobalAppMenu@lestcape/extension.js
@@ -2,6 +2,7 @@
 const Lang = imports.lang;
 const St = imports.gi.St;
 const Main = imports.ui.main;
+const Mainloop = imports.mainloop;
 
 //const GIRepository = imports.gi.GIRepository;
 const MyExtension = imports.misc.extensionUtils.getCurrentExtension();
@@ -16,12 +17,16 @@ function init() {
 }
 
 function enable() {
-    let activities = Main.panel.statusArea['activities'];
-    if(activities != null) {
-        activities.actor.get_parent().add_actor(applet.actor);
+
+    Mainloop.idle_add(Lang.bind(this, function () {
+        let _children = Main.panel._leftBox.get_children();
+
+        Main.panel._leftBox.insert_child_at_index(applet.actor, _children.length - 1);
         applet.on_applet_added_to_panel(false);
         applet.setOrientation(St.Side.TOP);
-    }
+
+        return false;
+    }));
 }
 
 function disable() {
@@ -29,9 +34,5 @@ function disable() {
     if(parent) {
         parent.remove_actor(applet.actor);
         applet.on_applet_removed_from_panel();
-        let activities = Main.panel.statusArea['activities'];
-        if(activities != null) {
-            parent.add_actor(activities.actor);
-        }
     }
 }


### PR DESCRIPTION
Now I know why I wasn't getting the menus: it's because I hid the "Activities" actor using the Hide Activities extension.  Here's a fix that will always add the menus even if the "Activities" is not there.  Also, I added a way to wait for idle adding of "applets" before it adds the menu (which I got from Window Buttons extension)

Now my setup looks almost like Unity: ![screenshot from 2017-04-20 22-02-00](https://cloud.githubusercontent.com/assets/1734126/25235165/efa644e6-2616-11e7-997b-96381f95efa3.png)
