### PR TITLE
Prepared to handled different menu providers

### DIFF
--- a/gnomeGlobalAppMenu@lestcape/applet.js
+++ b/gnomeGlobalAppMenu@lestcape/applet.js
@@ -84,7 +84,7 @@ KeybindingManager.prototype = {
     _sessionUpdated: function() {
         let sensitive = !Main.sessionMode.isLocked && !Main.sessionMode.isGreeter;
         if(sensitive) {
-            for (name in this.bindings) {
+            for (let name in this.bindings) {
                 this.addHotKeyArray(name, this.bindings[name].bindings, this.bindings[name].callback);
             }
             this.hackId = global.stage.connect('captured-event', Lang.bind(this, this._stageEventHandler));

--- a/gnomeGlobalAppMenu@lestcape/configurableMenus.js
+++ b/gnomeGlobalAppMenu@lestcape/configurableMenus.js
@@ -7145,6 +7145,7 @@ ConfigurableMenuApplet.prototype = {
       this._menuManager = menuManager;
       this._isSubMenuOpen = false;
       this._openOnHover = false;
+      this._startCounter = 0;
 
       this.launcher.actor.set_track_hover(this._floating);
       let parent = this.actor.get_parent();
@@ -7184,6 +7185,10 @@ ConfigurableMenuApplet.prototype = {
                menuItem.menu.fixToCorner(menuItem.menu.fixCorner);
          }
       }
+   },
+
+   setStartCounter: function(start) {
+       this._startCounter = start;
    },
 
    _updatePanelVisibility: function() {
@@ -7341,6 +7346,7 @@ ConfigurableMenuApplet.prototype = {
          if(position == undefined) {
             this.box.add(menuItem.actor, params);
          } else {
+            position += this._startCounter;
             let items = this.getMenuItems();
             if(position < items.length) {
                beforeItem = items[position].actor;

--- a/gnomeGlobalAppMenu@lestcape/extension.js
+++ b/gnomeGlobalAppMenu@lestcape/extension.js
@@ -17,22 +17,13 @@ function init() {
 }
 
 function enable() {
-
     Mainloop.idle_add(Lang.bind(this, function () {
-        let _children = Main.panel._leftBox.get_children();
-
-        Main.panel._leftBox.insert_child_at_index(applet.actor, _children.length - 1);
         applet.on_applet_added_to_panel(false);
         applet.setOrientation(St.Side.TOP);
-
         return false;
     }));
 }
 
 function disable() {
-    let parent = applet.actor.get_parent();
-    if(parent) {
-        parent.remove_actor(applet.actor);
-        applet.on_applet_removed_from_panel();
-    }
+    applet.on_applet_removed_from_panel();
 }

--- a/gnomeGlobalAppMenu@lestcape/settings-schema.json
+++ b/gnomeGlobalAppMenu@lestcape/settings-schema.json
@@ -21,6 +21,12 @@
         "description": "Enable the support for JAyatana (Experimental)",
         "tooltip": "Select if you want to enable the support for JAyatana."
     },
+    "replace-appmenu" : {
+        "type" : "checkbox",
+        "default" : false,
+        "description": "Use the extension as a replace of Gnome AppMenu",
+        "tooltip": "Select if you want to use the extension as a replace of Gnome AppMenu."
+    },
     "separator-application-top" : {
         "type": "separator"
     },

--- a/gnomeGlobalAppMenu@lestcape/settings/keybindingWidgets.js
+++ b/gnomeGlobalAppMenu@lestcape/settings/keybindingWidgets.js
@@ -244,13 +244,19 @@ const CellRendererKeybinding = new GObject.Class({
         event = this.press_event;
 
         let display = widget.get_display();
+        let keymap = Gdk.Keymap.get_for_display(display);
         let [, keyval] = event.get_keyval();
         let group = event.group;
         let [, accel_mods] = event.get_state();
-
-        if(group === undefined)
+        //gnome-shell-extension-prefs gnomeGlobalAppMenu@lestcape
+        //FIXME: Aparently gnome shell send a GdK.Event instead of a GDK.KeyEvent
+        if(group === undefined) {
             group = 0;
-
+            let [ok, keys] = keymap.get_entries_for_keyval(keyval);
+            if(ok && keys.length > 0) {
+                group = keys[0].group;
+            }
+        }
         // HACK: we don't want to use SysRq as a keybinding (but we do
         // want Alt+Print), so we avoid translation from Alt+Print to SysRq
         let consumed_modifiers;
@@ -259,7 +265,6 @@ const CellRendererKeybinding = new GObject.Class({
             keyval = Gdk.KEY_Print;
             consumed_modifiers = 0;
         } else {
-            let keymap = Gdk.Keymap.get_for_display(display);
             let group_mask_disabled = false;
             let shift_group_mask = 0;
 


### PR DESCRIPTION
Split the process in providers to be possible use the X11 and the Wayland compositor, because the Wayland compositor won't handled the xid of the window. In that way we also isolate problems that will come form specific backends and prepared the extension to support the new qt Dbus model. Also fixed some other issues and add an option to replace the gnome appmenu.